### PR TITLE
fix(fragments): Fix RandomFragment's default getValue() behavior

### DIFF
--- a/src/FragmentBase.ts
+++ b/src/FragmentBase.ts
@@ -57,7 +57,7 @@ export default abstract class FragmentBase {
       );
 
     this.value = BigInt(0);
-    this.maxValue = BigInt(2 ** bits) - BigInt(1);
+    this.maxValue = (BigInt(1) << BigInt(bits)) - BigInt(1);
 
     this.identifier = this.constructor.name;
   }

--- a/src/Fragments/RandomFragment.ts
+++ b/src/Fragments/RandomFragment.ts
@@ -43,16 +43,16 @@ export default class RandomFragment extends FragmentBase {
       return rndNum;
     }
 
-    if (this.bits <= 48)
-      return BigInt(randomInt(0, Number((1n << BigInt(this.bits)) - 1n)));
+    if (this.bits <= 47)
+      return BigInt(randomInt(0, Number(1n << BigInt(this.bits))));
 
-    // 48 bit parts due to randomInt range limitation
+    // 47 bit parts due to randomInt range limitation
     // max param limit of Number.MAX_SAFE_INTEGER
     let rndNum = BigInt(0);
-    for (let i = 0; i < this.bits; i += 48) {
-      rndNum +=
+    for (let i = 0; i < this.bits; i += 47) {
+      rndNum |=
         BigInt(
-          randomInt(0, Number((1n << BigInt(Math.min(this.bits - i, 48))) - 1n)),
+          randomInt(0, Number(1n << BigInt(Math.min(this.bits - i, 47)))),
         ) << BigInt(i);
     }
 

--- a/src/Fragments/RandomFragment.ts
+++ b/src/Fragments/RandomFragment.ts
@@ -15,7 +15,7 @@ export default class RandomFragment extends FragmentBase {
    * @param bits - The number of bits for the fragment.
    * @param fn - Optional custom random function.
    *
-   * @throws `[RND_FUNCTION_RETURN_TYPE]` If custom function does not return number or bigint.
+   * @throws `[RND_FUNCTION_RETURN_TYPE]` If custom function does not return number or bigint, or if the value is out of range.
    */
   constructor(bits: number, private readonly fn?: () => number | bigint) {
     super(bits);
@@ -37,7 +37,7 @@ export default class RandomFragment extends FragmentBase {
 
       if (rndNum >= 1n << BigInt(this.bits))
         throw new TypeError(
-          `[RND_FUNCTION_BAD_RETURN]: RandomFragment custom function returned a value bigger than 2 ** ${this.bits} - 1.`,
+          `[RND_FUNCTION_BAD_RETURN]: RandomFragment custom function returned a value bigger than (2 ** ${this.bits}) - 1.`,
         );
 
       return rndNum;
@@ -51,9 +51,8 @@ export default class RandomFragment extends FragmentBase {
     let rndNum = BigInt(0);
     for (let i = 0; i < this.bits; i += 47) {
       rndNum |=
-        BigInt(
-          randomInt(0, Number(1n << BigInt(Math.min(this.bits - i, 47)))),
-        ) << BigInt(i);
+        BigInt(randomInt(0, Number(1n << BigInt(Math.min(this.bits - i, 47))))) <<
+        BigInt(i);
     }
 
     return rndNum;

--- a/test/Snowflakify.test.ts
+++ b/test/Snowflakify.test.ts
@@ -161,6 +161,26 @@ test('improper SequenceFragment instantiation throws', () => {
   expect(() => new SequenceFragment(0)).toThrow();
 });
 
-test.todo(
-  'implement tests for RandomFragment default and custom function randomness',
+test.each([5, 8, 16, 48, 63, 64, 128, 65537])(
+  'RandomFragment values with default function (%i-bits)',
+  (bits) => {
+    const fragment = new RandomFragment(bits);
+    const val = fragment.getValue();
+
+    expect(val).toBeGreaterThanOrEqual(0n);
+    expect(val).toBeLessThan(1n << BigInt(bits));
+    // Check that most significant digit can be 1.
+    // Random numbers are inconsistent, we need enough iterations to be reasonably sure.
+    expect(
+      [...Array(20)].some(
+        (): boolean => fragment.getValue() >> BigInt(bits - 1) > 0n,
+      ),
+    ).toBe(true);
+  },
 );
+
+test('RandomFragment values with custom function', () => {
+  expect(() => new RandomFragment(8, () => -1).getValue()).toThrow(TypeError);
+  expect(() => new RandomFragment(8, () => 257).getValue()).toThrow(TypeError);
+  expect(new RandomFragment(8, () => 4).getValue()).toBe(4n);
+});

--- a/test/Snowflakify.test.ts
+++ b/test/Snowflakify.test.ts
@@ -96,8 +96,12 @@ test('proper TimestampFragment instantiation', () => {
   // @ts-ignore
   expect(timestampFragment.epoch).toBe(BigInt(1420070400000));
   expect(timestampFragment.bitShift).toBe(BigInt(22));
-  expect(timestampFragment.bitMask).toBe(BigInt(18446744073705357312));
+  expect(timestampFragment.bitMask).toBe(BigInt(18446744073705357312n));
   expect(timestampFragment.bitMaskHex).toBe('0xffffffffffc00000');
+
+  expect(new TimestampFragment(1025).maxValue).toBe(
+    BigInt(`0x1${'ff'.repeat(128)}`),
+  );
 });
 
 test('improper TimestampFragment instantiation throws', () => {

--- a/test/Snowflakify.test.ts
+++ b/test/Snowflakify.test.ts
@@ -96,7 +96,7 @@ test('proper TimestampFragment instantiation', () => {
   // @ts-ignore
   expect(timestampFragment.epoch).toBe(BigInt(1420070400000));
   expect(timestampFragment.bitShift).toBe(BigInt(22));
-  expect(timestampFragment.bitMask).toBe(BigInt(18446744073705357312n));
+  expect(timestampFragment.bitMask).toBe(18446744073705357312n);
   expect(timestampFragment.bitMaskHex).toBe('0xffffffffffc00000');
 
   expect(new TimestampFragment(1025).maxValue).toBe(


### PR DESCRIPTION
Without a custom random function, `RandomFragment.getValue()` method's default behavior typically outputs 16-bit numbers (larger values are possible in certain conditions). This is because it almost completely disregards the value of the `bits` parameter passed to the constructor. In addition to that, Javascript's bitshift operators treat standard number operands as 32-bit integers, so `1 << 48` turns into `1 << 16`. This pull request should fix the unintended bugs and I added tests to ensure the correct output.

I also noticed a small bug in `FragmentBase.maxValue` calculation. `2 ** bits` will produce unsafe integers before being wrapped into a BigInt when `bits > 52`, although this doesn't actually matter in this case since the trimmed bits are always zeroes. However, if someone was to do something silly, like use `bits >= 1024`, this will cause the number to overflow into `Infinity`, subsequently causing BigInt wrapper to throw a RangeError. This is of course a very rare use case, but I figured it'd be a good idea to fix it anyway.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed max-value calculation and random generation logic so produced values reliably fall within intended ranges for all supported bit widths.
  * Improved validation to reject negative or out-of-range results from custom randomness providers.

* **Tests**
  * Expanded and strengthened tests across many bit widths and scenarios, including explicit checks for timestamp fragment limits and custom RNG behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->