### PR TITLE
use full 'import from' relative paths

### DIFF
--- a/src/FragmentBase.ts
+++ b/src/FragmentBase.ts
@@ -1,4 +1,4 @@
-import { DestructuredFragment } from './@types';
+import { DestructuredFragment } from './@types/index.js';
 
 /**
  * Base class for fragments.

--- a/src/Fragments/NetworkFragment.ts
+++ b/src/Fragments/NetworkFragment.ts
@@ -1,6 +1,6 @@
 import FragmentBase from '../FragmentBase.js';
 import { getIPv4Address, getMacAddress } from '../Utils/Util.js';
-import { DestructuredFragment } from '../@types';
+import { DestructuredFragment } from '../@types/index.js';
 
 /**
  * NetworkFragment class for network IDs.

--- a/src/Fragments/ProcessFragment.ts
+++ b/src/Fragments/ProcessFragment.ts
@@ -1,6 +1,6 @@
 import process from 'process';
 import FragmentBase from '../FragmentBase.js';
-import { DestructuredFragment } from '../@types';
+import { DestructuredFragment } from '../@types/index.js';
 
 /**
  * ProcessFragment class for process IDs.

--- a/src/Fragments/RandomFragment.ts
+++ b/src/Fragments/RandomFragment.ts
@@ -1,6 +1,6 @@
 import { randomInt } from 'crypto';
 import FragmentBase from '../FragmentBase.js';
-import { DestructuredFragment } from '../@types';
+import { DestructuredFragment } from '../@types/index.js';
 
 /**
  * RandomFragment class for random IDs.

--- a/src/Fragments/SequenceFragment.ts
+++ b/src/Fragments/SequenceFragment.ts
@@ -1,5 +1,5 @@
 import FragmentBase from '../FragmentBase.js';
-import { DestructuredFragment } from '../@types';
+import { DestructuredFragment } from '../@types/index.js';
 
 /**
  * SequenceFragment class for sequence (increment/counter) IDs.

--- a/src/Fragments/TimestampFragment.ts
+++ b/src/Fragments/TimestampFragment.ts
@@ -1,7 +1,7 @@
 import { hrtime } from 'process';
 import FragmentBase from '../FragmentBase.js';
 import SequenceFragment from './SequenceFragment.js';
-import { DestructuredFragment } from '../@types';
+import { DestructuredFragment } from '../@types/index.js';
 
 const DEFAULT_EPOCH = 1420070400000;
 

--- a/src/Fragments/WorkerFragment.ts
+++ b/src/Fragments/WorkerFragment.ts
@@ -1,7 +1,7 @@
 import { isMainThread, threadId } from 'worker_threads';
 import cluster from 'cluster';
 import FragmentBase from '../FragmentBase.js';
-import { DestructuredFragment } from '../@types';
+import { DestructuredFragment } from '../@types/index.js';
 
 /**
  * WorkerFragment class for worker IDs.

--- a/src/Snowflakify.ts
+++ b/src/Snowflakify.ts
@@ -1,5 +1,9 @@
 import { isMainThread } from 'worker_threads';
-import { FragmentArray, SnowflakifyOptions, DestructuredFragment } from './@types';
+import {
+  FragmentArray,
+  SnowflakifyOptions,
+  DestructuredFragment,
+} from './@types/index.js';
 import { TimestampFragment, SequenceFragment } from './index.js';
 import Options from './Utils/Options.js';
 import CircularBuffer from './CircularBuffer/CircularBuffer.js';


### PR DESCRIPTION
Dependents of this library that use typescript and have `"moduleResolution": "node16"` or `"moduleResolution": "nodenext"`, and `"skipLibCheck": false` will get TS2834 errors. While these errors can be supressed with the `skipLibCheck` option, doing so will supress all errors in all '*.d.ts' files, including ones in their own project. This PR completes the paths of all relative imports.

Example of a TS2834 error from tsc's output:
`node_modules/snowflakify/dist/mjs/FragmentBase.d.ts(1,38): error TS2834: Relative import paths need explicit file extensions in ECMAScript imports when '--moduleResolution' is 'node16' or 'nodenext'. Consider adding an extension to the import path.`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal module resolution paths for type imports across multiple files. No changes to functionality or user-facing features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->